### PR TITLE
Updates haproxy.cfg.j2 to support ha-proxy 1.6.x

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -23,7 +23,8 @@ defaults
         maxconn 4096
 
 {% if haproxy_stats_enabled | bool %}
-listen stats {{ haproxy_stats_bind_address }}:{{ haproxy_stats_port }}
+listen stats
+    bind {{ haproxy_stats_bind_address }}:{{ haproxy_stats_port }}
     mode http
     stats enable
     stats hide-version


### PR DESCRIPTION
This format is backwards compatible with ha-proxy 1.5.x
